### PR TITLE
Tweaks to improve doorway placement

### DIFF
--- a/core/src/main/java/technology/rocketjump/mountaincore/mapping/MapMessageHandler.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/mapping/MapMessageHandler.java
@@ -366,6 +366,17 @@ public class MapMessageHandler implements Telegraph, GameContextAware {
 											messageDispatcher.dispatchMessage(MessageType.REMOVE_DESIGNATION, new RemoveDesignationMessage(tile));
 										}
 										if (tile.hasConstruction()) {
+											if (tile.hasWallConstruction()) {
+												for (MapTile neighbourTile : gameContext.getAreaMap().getOrthogonalNeighbours(x, y).values()) {
+													if (neighbourTile.hasDoorway()) {
+														messageDispatcher.dispatchMessage(MessageType.DECONSTRUCT_DOOR, neighbourTile.getDoorway());
+													}
+													if (neighbourTile.hasDoorwayConstruction()) {
+														messageDispatcher.dispatchMessage(MessageType.CANCEL_CONSTRUCTION, neighbourTile.getConstruction());
+													}
+												}
+											}
+
 											messageDispatcher.dispatchMessage(MessageType.CANCEL_CONSTRUCTION, tile.getConstruction());
 										}
 									}
@@ -834,6 +845,9 @@ public class MapMessageHandler implements Telegraph, GameContextAware {
 				}
 				if (neighbourTile.hasDoorway()) {
 					messageDispatcher.dispatchMessage(MessageType.DECONSTRUCT_DOOR, neighbourTile.getDoorway());
+				}
+				if (neighbourTile.hasDoorwayConstruction()) {
+					messageDispatcher.dispatchMessage(MessageType.CANCEL_CONSTRUCTION, neighbourTile.getConstruction());
 				}
 				if (neighbourTile.hasRoom()) {
 					neighbourTile.getRoomTile().getRoom().checkIfEnclosed(gameContext.getAreaMap());

--- a/core/src/main/java/technology/rocketjump/mountaincore/mapping/tile/MapTile.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/mapping/tile/MapTile.java
@@ -190,6 +190,10 @@ public class MapTile implements Persistable {
 		return this.wall != null;
 	}
 
+	public boolean hasWallConstruction() {
+		return getConstruction() != null && getConstruction().getConstructionType() == ConstructionType.WALL_CONSTRUCTION;
+	}
+
 	public boolean isNavigable(Entity requestingEntity) {
 		return isNavigable(requestingEntity, null);
 	}
@@ -472,6 +476,10 @@ public class MapTile implements Persistable {
 
 	public boolean hasDoorway() {
 		return doorway != null;
+	}
+
+	public boolean hasDoorwayConstruction() {
+		return construction != null && construction.getConstructionType() == ConstructionType.DOORWAY_CONSTRUCTION;
 	}
 
 	public Doorway getDoorway() {
@@ -786,7 +794,7 @@ public class MapTile implements Persistable {
 	public boolean hasPowerMechanism() {
 		return underTile != null && underTile.getPowerMechanismEntity() != null;
 	}
-
+	
 	public enum RegionType {
 		RIVER, WALL, CHANNEL, GENERIC
 	}

--- a/core/src/main/java/technology/rocketjump/mountaincore/ui/GameInteractionStateContainer.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/ui/GameInteractionStateContainer.java
@@ -494,7 +494,7 @@ public class GameInteractionStateContainer implements GameContextAware {
 
 	private DoorwayPlacementMessage isDoorPlacementValid(TiledMap map, GridPoint2 tilePosition) {
 		MapTile targetTile = map.getTile(tilePosition);
-		if (targetTile == null || !targetTile.isEmptyExceptItemsAndPlants()) {
+		if (targetTile == null || (!targetTile.isEmptyExceptItemsAndPlants() && !targetTile.hasWallConstruction())) {
 			return null;
 		}
 
@@ -507,13 +507,19 @@ public class GameInteractionStateContainer implements GameContextAware {
 			return null;
 		}
 
-		if (north.hasWall() && south.hasWall() && east.isEmptyExceptEntities() && west.isEmptyExceptEntities()) {
+
+		boolean northWall = north.hasWall() || north.hasWallConstruction();
+		boolean southWall = south.hasWall() || south.hasWallConstruction();
+		boolean westWall = west.hasWall() || west.hasWallConstruction();
+		boolean eastWall = east.hasWall() || east.hasWallConstruction();
+
+		if (northWall && southWall && east.isEmptyExceptEntities() && west.isEmptyExceptEntities()) {
 			return new DoorwayPlacementMessage(DoorwaySize.SINGLE, DoorwayOrientation.NORTH_SOUTH, doorMaterialSelection.selectedMaterialType,
 					doorMaterialSelection.selectedMaterial, tilePosition);
 		}
 
 
-		if (west.hasWall() && east.hasWall() && north.isEmptyExceptEntities() && south.isEmptyExceptEntities()) {
+		if (westWall && eastWall && north.isEmptyExceptEntities() && south.isEmptyExceptEntities()) {
 			return new DoorwayPlacementMessage(DoorwaySize.SINGLE, DoorwayOrientation.EAST_WEST, doorMaterialSelection.selectedMaterialType,
 					doorMaterialSelection.selectedMaterial, tilePosition);
 		}

--- a/core/src/main/java/technology/rocketjump/mountaincore/ui/GuiMessageHandler.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/ui/GuiMessageHandler.java
@@ -337,7 +337,13 @@ public class GuiMessageHandler implements Telegraph, GameContextAware {
 				}
 			} else if (interactionStateContainer.getInteractionMode().equals(GameInteractionMode.PLACE_DOOR)) {
 				if (interactionStateContainer.isValidDoorPlacement()) {
-					messageDispatcher.dispatchMessage(MessageType.DOOR_PLACEMENT, interactionStateContainer.getVirtualDoorPlacement());
+					DoorwayPlacementMessage doorPlacement = interactionStateContainer.getVirtualDoorPlacement();
+					MapTile tile = gameContext.getAreaMap().getTile(doorPlacement.getTilePosition());
+					if (tile.hasWallConstruction()) {
+						messageDispatcher.dispatchMessage(MessageType.CANCEL_CONSTRUCTION, tile.getConstruction());
+					}
+
+					messageDispatcher.dispatchMessage(MessageType.DOOR_PLACEMENT, doorPlacement);
 				}
 			} else if (interactionStateContainer.getInteractionMode().equals(GameInteractionMode.SQUAD_MOVE_TO_LOCATION)) {
 				MapTile cursorTile = gameContext.getAreaMap().getTile(mouseChangeMessage.getWorldPosition());


### PR DESCRIPTION
This will allow placing of a door between two valid wall constructions, as well as replacing a wall construction with a doorway if valid We also remove the doorway [& construction] if the supporting walls are destroyed and/or cancelled.