### PR TITLE
Changing log file writer to only write up to 2mb of logs. This is to …

### DIFF
--- a/core/src/main/resources/tinylog.properties
+++ b/core/src/main/resources/tinylog.properties
@@ -3,6 +3,8 @@ tinylog.level = debug
 tinylog.writer1 = console
 tinylog.writer1.format = {level}: {message}
 
-tinylog.writer2 = file
+tinylog.writer2 = rollingfile
 tinylog.writer2.filename = log.txt
 tinylog.writer2.format = {level}: {message}
+tinylog.writer2.policies = startup, size: 1MB
+tinylog.writer2.backups = 2


### PR DESCRIPTION
…prevent disk filling up with a log (e.g. a log in render loop can cause this)