### PR TITLE
Fixes and improvements to butchery station

### DIFF
--- a/core/src/main/java/technology/rocketjump/mountaincore/entities/ItemEntityMessageHandler.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/entities/ItemEntityMessageHandler.java
@@ -403,11 +403,16 @@ public class ItemEntityMessageHandler implements GameContextAware, Telegraph {
 	}
 
 	public static Job createHaulingJob(HaulingAllocation haulingAllocation, Entity itemEntity, JobType haulingJobType, JobPriority jobPriority) {
+
 		Job haulingJob = new Job(haulingJobType);
 		haulingJob.setTargetId(itemEntity.getId());
 		haulingJob.setJobLocation(VectorUtils.toGridPoint(itemEntity.getLocationComponent().getWorldOrParentPosition()));
 		haulingJob.setHaulingAllocation(haulingAllocation);
-		haulingJob.setJobPriority(jobPriority);
+		if (jobPriority == JobPriority.DISABLED) {
+			haulingJob.setJobPriority(JobPriority.LOWEST);
+		} else {
+			haulingJob.setJobPriority(jobPriority);
+		}
 		return haulingJob;
 	}
 

--- a/core/src/main/java/technology/rocketjump/mountaincore/entities/behaviour/furniture/ButcheryStationBehaviour.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/entities/behaviour/furniture/ButcheryStationBehaviour.java
@@ -102,9 +102,11 @@ public class ButcheryStationBehaviour extends FurnitureBehaviour implements Prio
 			if (inventoryEntry.entity.getType().equals(EntityType.ITEM)) {
 				ItemAllocationComponent itemAllocationComponent = inventoryEntry.entity.getComponent(ItemAllocationComponent.class);
 				if (itemAllocationComponent.getNumUnallocated() > 0) {
-					messageDispatcher.dispatchMessage(MessageType.REQUEST_ENTITY_HAULING, new RequestHaulingMessage(
+					RequestHaulingMessage requestHaulingMessage = new RequestHaulingMessage(
 							inventoryEntry.entity, parentEntity, true, priority, job -> haulingJobs.add(job)
-					));
+					);
+					requestHaulingMessage.setSpecificProfessionRequired(requiredProfession);
+					messageDispatcher.dispatchMessage(MessageType.REQUEST_ENTITY_HAULING, requestHaulingMessage);
 				}
 			}
 		}

--- a/core/src/main/java/technology/rocketjump/mountaincore/jobs/JobPriorityUpdater.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/jobs/JobPriorityUpdater.java
@@ -1,0 +1,62 @@
+package technology.rocketjump.mountaincore.jobs;
+
+import com.badlogic.gdx.Gdx;
+import technology.rocketjump.mountaincore.gamecontext.GameContext;
+import technology.rocketjump.mountaincore.gamecontext.Updatable;
+import technology.rocketjump.mountaincore.jobs.model.Job;
+import technology.rocketjump.mountaincore.jobs.model.JobPriority;
+import technology.rocketjump.mountaincore.jobs.model.JobType;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collection;
+
+@Singleton
+public class JobPriorityUpdater implements Updatable {
+
+    private static final float UPDATE_PERIOD_SECONDS = 1.0f;
+
+    private final JobStore jobStore;
+    private final JobType haulingJobType;
+    private GameContext gameContext;
+    private float deltaTimeAcc;
+
+    @Inject
+    public JobPriorityUpdater(JobStore jobStore, JobTypeDictionary jobTypeDictionary) {
+        this.jobStore = jobStore;
+        this.haulingJobType = jobTypeDictionary.getByName("HAULING");
+    }
+
+    @Override
+    public void onContextChange(GameContext gameContext) {
+        this.gameContext = gameContext;
+    }
+
+    @Override
+    public void clearContextRelatedState() {
+
+    }
+
+    @Override
+    public void update(float otherDeltaTime) {
+        final float deltaTime = Gdx.graphics.getDeltaTime();
+        if (gameContext != null) {
+            deltaTimeAcc += deltaTime;
+            if (deltaTimeAcc > UPDATE_PERIOD_SECONDS) {
+                deltaTimeAcc = 0f;
+
+                Collection<Job> haulingJobs = jobStore.getByType(haulingJobType);
+                for (Job haulingJob : haulingJobs) {
+                    if (JobPriority.DISABLED == haulingJob.getJobPriority()) {
+                        haulingJob.setJobPriority(JobPriority.HIGHEST); //when detecting an issue/broken job. Shouldn't really happen
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean runWhilePaused() {
+        return true;
+    }
+}


### PR DESCRIPTION
- Use the chef profession to haul out of the station, instead of waiting for hauler
- Updater job that moves Disabled hauling to tackle immediately, this shouldn't really happen
- Dissallow requesting hauling job with disabled state. This can cause a mess as these jobs may not be managed/tracked, but lock up a behaviour