### PR TITLE
Fix crash on assigning military equip without current goal

### DIFF
--- a/core/src/main/java/technology/rocketjump/mountaincore/entities/components/creature/MilitaryComponent.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/entities/components/creature/MilitaryComponent.java
@@ -3,6 +3,7 @@ package technology.rocketjump.mountaincore.entities.components.creature;
 import com.alibaba.fastjson.JSONObject;
 import com.badlogic.gdx.ai.msg.MessageDispatcher;
 import org.apache.commons.lang3.NotImplementedException;
+import technology.rocketjump.mountaincore.entities.ai.goap.AssignedGoal;
 import technology.rocketjump.mountaincore.entities.behaviour.creature.CreatureBehaviour;
 import technology.rocketjump.mountaincore.entities.components.*;
 import technology.rocketjump.mountaincore.entities.model.Entity;
@@ -177,9 +178,12 @@ public class MilitaryComponent implements InfrequentlyUpdatableComponent, Destru
 
 	private HaulingAllocation getCurrentHaulingAllocation(Long itemId) {
 		if (parentEntity.getBehaviourComponent() instanceof CreatureBehaviour creatureBehaviour) {
-			HaulingAllocation currentlyHauling = creatureBehaviour.getCurrentGoal().getAssignedHaulingAllocation();
-			if (currentlyHauling != null && Objects.equals(currentlyHauling.getHauledEntityId(), itemId)) {
-				return currentlyHauling;
+			AssignedGoal currentGoal = creatureBehaviour.getCurrentGoal();
+			if (currentGoal != null) {
+				HaulingAllocation currentlyHauling = currentGoal.getAssignedHaulingAllocation();
+				if (currentlyHauling != null && Objects.equals(currentlyHauling.getHauledEntityId(), itemId)) {
+					return currentlyHauling;
+				}
 			}
 		}
 		ItemAssignmentComponent itemAssignmentComponent = parentEntity.getOrCreateComponent(ItemAssignmentComponent.class);


### PR DESCRIPTION
When Settler does not have current goal (like hauling something), when switched to military and assigning equipment (armor/weapon...), game would crash when attempting to compare if current goal is not already to fetch the equipment due to the settler not having any goal.

(Not sure if it can happen normally, but easy to reproduce
 using debug menu, when in paused state, by spawning settler,
 switching to military and assigning from available equip).

Trace (part, and from Steam version) looks as:

```
  ERROR: java.lang.NullPointerException: Cannot invoke "technology.rocketjump.mountaincore.entities.ai.goap.AssignedGoal.getAssignedHaulingAllocation()"
  because the return value of "technology.rocketjump.mountaincore.entities.behaviour.creature.CreatureBehaviour.getCurrentGoal()" is null
    at technology.rocketjump.mountaincore.entities.components.creature.MilitaryComponent.getCurrentHaulingAllocation(MilitaryComponent.java:180)
    at technology.rocketjump.mountaincore.entities.components.creature.MilitaryComponent.createHaulingAllocationIfRequired(MilitaryComponent.java:161)
    at technology.rocketjump.mountaincore.entities.components.creature.MilitaryComponent.infrequentUpdate(MilitaryComponent.java:104)
    at technology.rocketjump.mountaincore.screens.SettlerManagementScreen.lambda$weaponSelection$10(SettlerManagementScreen.java:575)
    at technology.rocketjump.mountaincore.screens.SettlerManagementScreen$9.lambda$clicked$2(SettlerManagementScreen.java:605)
    at technology.rocketjump.mountaincore.screens.SettlerManagementScreen$SelectItemOption.onSelect(SettlerManagementScreen.java:806)
    at technology.rocketjump.mountaincore.ui.widgets.SelectItemDialog$1.clicked(SelectItemDialog.java:68)
```