### PR TITLE
[BUG-Report] NullPointerException when Entity attacks while weapon has no material

### DIFF
--- a/core/src/main/java/technology/rocketjump/mountaincore/entities/ai/combat/AttackCreatureCombatAction.java
+++ b/core/src/main/java/technology/rocketjump/mountaincore/entities/ai/combat/AttackCreatureCombatAction.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.JSONObject;
 import com.badlogic.gdx.ai.msg.MessageDispatcher;
 import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.math.Vector2;
+import org.pmw.tinylog.Logger;
 import technology.rocketjump.mountaincore.combat.model.WeaponAttack;
 import technology.rocketjump.mountaincore.entities.components.InventoryComponent;
 import technology.rocketjump.mountaincore.entities.components.creature.CombatStateComponent;
@@ -119,11 +120,23 @@ public class AttackCreatureCombatAction extends CombatAction implements Particle
 	private void triggerAttack(Entity targetedEntity, MessageDispatcher messageDispatcher) {
 		CreatureCombat creatureCombat = new CreatureCombat(parentEntity);
 		ItemEntityAttributes ammoAttributes = decrementAmmoFromInventory(creatureCombat.getEquippedWeapon().getRequiresAmmoType(), messageDispatcher);
-		messageDispatcher.dispatchMessage(MessageType.MAKE_ATTACK_WITH_WEAPON, new CombatAttackMessage(
-				parentEntity, targetedEntity, new WeaponAttack(creatureCombat.getEquippedWeapon(),
-				creatureCombat.getEquippedWeaponQuality(),
-				creatureCombat.getEquippedWeaponAttributes().getPrimaryMaterial()),
-				ammoAttributes));
+		try {
+			messageDispatcher.dispatchMessage(MessageType.MAKE_ATTACK_WITH_WEAPON, new CombatAttackMessage(
+						parentEntity, targetedEntity, new WeaponAttack(creatureCombat.getEquippedWeapon(),
+							creatureCombat.getEquippedWeaponQuality(),
+							creatureCombat.getEquippedWeaponAttributes().getPrimaryMaterial()),
+						ammoAttributes));
+		} catch (NullPointerException exc) {
+			// Suspect it may be UNARMED weapon, need to confirm somehow
+			Logger.error("Entity {} unable to attack {} with {} (unarmed: {}, sprite: {}, damageType: {}))",
+					parentEntity,
+					targetedEntity,
+					creatureCombat.getEquippedWeapon(),
+					WeaponInfo.UNARMED.equals(creatureCombat.getEquippedWeapon()),
+					creatureCombat.getEquippedWeapon().getAnimatedSpriteEffectName(),
+					creatureCombat.getEquippedWeapon().getDamageType().name());
+			throw exc;
+		}
 		attackMade = true;
 	}
 


### PR DESCRIPTION
// Please consider this currently as bug report ... since there are no Issues open on this repo ... currently I have no clue yet what caused it and how it could be prevented/fixed.

After Orcs Invaded settlement (still in the camping phase), something started fight and game crashed.

Currently do not know what happened yet,
so attempt to get more details logged.
(Based on code i suspect it may be for example case of UNARMED weapon,
 as set at start of CreatureCombat constructor while not setting
 equippedWeaponQuality so would be left as null.)

ERROR: java.lang.NullPointerException: Cannot invoke "technology.rocketjump.mountaincore.entities.model.physical.item.ItemEntityAttributes.getPrimaryMaterial()" because the return value of "technology.rocketjump.mountaincore.entities.ai.combat.CreatureCombat.getEquippedWeaponAttributes()" is null
        at technology.rocketjump.mountaincore.entities.ai.combat.AttackCreatureCombatAction.triggerAttack(AttackCreatureCombatAction.java:125)
        at technology.rocketjump.mountaincore.entities.ai.combat.AttackCreatureCombatAction.update(AttackCreatureCombatAction.java:75)
        at technology.rocketjump.mountaincore.entities.behaviour.creature.CombatBehaviour.update(CombatBehaviour.java:140)
        at technology.rocketjump.mountaincore.entities.behaviour.creature.CreatureBehaviour.update(CreatureBehaviour.java:127)
        at technology.rocketjump.mountaincore.entities.model.Entity.update(Entity.java:232)
        at technology.rocketjump.mountaincore.entities.EntityUpdater.update(EntityUpdater.java:32)
        at technology.rocketjump.mountaincore.gamecontext.GameUpdateRegister.update(GameUpdateRegister.java:32)